### PR TITLE
Tire::Results::Collection: Ensure @response['hits'] exists before loading results

### DIFF
--- a/lib/tire/results/collection.rb
+++ b/lib/tire/results/collection.rb
@@ -71,7 +71,7 @@ module Tire
       end
 
       def success?
-        error.to_s.empty?
+        error.to_s.empty? && @response['hits']
       end
 
       def failure?


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/107967846

Here is an example exception from the Doximity app:
https://bugsnag.com/doximity/doximity/errors/56019e8c1f5f9f6e0be06874?filters%5Bevent.message%5D%5B%5D=undefined+method+%60%5B%5D%27+for+nil%3ANilClass

with a stack trace that points to:
![lpyntp7nzuhybbv9ydign6btl8yxamr5muvkyqhie00](https://cloud.githubusercontent.com/assets/1890473/11109696/1c9b75e2-88a8-11e5-91b1-91be3f2ef90e.png)

Tire assumes that if `@response['error']` is empty that the response was a `success?`.  If the body of the response is empty however (`"{}"`), `success?` will return true but `@response['hits']` will be nil and fail at the line highlighted above.

Many more examples here:
https://bugsnag.com/doximity/doximity/errors?filters[error.status][]=open&filters[event.message][]=undefined%20method%20%60%5B%5D%27%20for%20nil%3ANilClass